### PR TITLE
GitHub actions to build and publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    steps:
+    - name: Checkout Branch
+      uses: actions/checkout@v1
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        version: 12
+    - name: Build Extension
+      run: |
+        npm install
+        npm run compile
+    - name: Package Extension
+      run: |
+        npm install -g vsce
+        vsce package
+        mkdir vsix
+        mv *.vsix vsix
+    - name: Archive Extension
+      uses: actions/upload-artifact@v1
+      with:
+        name: vsix
+        path: vsix

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Build & Publish
+on: [workflow_dispatch]
+
+jobs:
+  build:
+    name: release
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14
+    # Run install dependencies
+    - name: Install dependencies
+      run: npm install
+    # Run tests
+    - name: Build 
+      run: npm run compile
+    - name: Get current package version
+      id: package_version
+      uses: martinbeentjes/npm-get-version-action@v1.1.0
+    - name: Check version is mentioned in Changelog
+      uses: mindsers/changelog-reader-action@v2.0.0
+      with:
+        version: ${{ steps.package_version.outputs.current-version }}
+        path: 'CHANGELOG.md'
+    - name: Create a Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+      with:
+        tag_name : ${{ steps.package_version.outputs.current-version}}
+        release_name: ${{ steps.package_version.outputs.current-version}}
+        body: Publish ${{ steps.package_version.outputs.current-version}}
+    - name: Create vsix and publish to marketplace
+      id: create_vsix
+      uses: HaaLeo/publish-vscode-extension@v0
+      with:
+        pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+        registryUrl: https://marketplace.visualstudio.com
+    - name: Attach vsix to release
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ steps.create_vsix.outputs.vsixPath}}
+        asset_name: ${{ steps.create_vsix.outputs.vsixPath}}
+        asset_content_type: application/vsix
+    
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Visual Studio Code Porter Tools
+
+## Maintenance
+
+* [How to release](maintenance/README.md)
+

--- a/docs/maintenance/README.md
+++ b/docs/maintenance/README.md
@@ -1,0 +1,24 @@
+## How to Release
+
+To make a new release and publish it to the marketplace you have to follow the following steps.
+
+1. Create a branch `publish-x.y.z`
+2. Update `package.json` with the new version 
+3. Add a section to `CHANGELOG.md` with the header `## [x.y.z]` (N.B: make sure to write the new version in square brackets as the `changelog-reader` action only works if the `CHANGELOG.md` file follows the [Keep a Changelog standard](https://github.com/olivierlacan/keep-a-changelog))
+4. Create a new PR, get approval and merge
+5. Run the `Build & Publish` workflow manually from the GH Actions tab
+
+### Build & Publish 
+
+The `Build & Publish` workflow allows to create a new release, package it in a VSIX file and publish to the VSCode marketplace with a single click.
+
+The only requirement needed to run the workflow is to have a secret named `VS_MARKETPLACE_TOKEN` containing the Personal Access Token of the publisher. You can find more infos about how to create a publisher/token in the [official documentation](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#create-a-publisher)
+
+Once everything is set up and you followed all first 4 steps in the previous section, you are ready to trigger the `Build & Publish` workflow.
+This is what it actually does:
+
+1. Install all dependencies and build the project
+2. Check if the `CHANGELOG.md` contains a section related to the new version
+3. Create a new release
+4. Create the VSIX file and publish it to the marketplace
+5. Attach the VSIX file to the new release


### PR DESCRIPTION
Provides GitHub actions to build and publish the extension.

* The `build.yml` action builds the extension on every PR and merge to main.  It compiles the TypeScript, packages a VSIX, and archives the VSIX as a build artifact.  This means that 1. we check that packaging works (will be doubly important if/when we webpack it) and 2. there are binaries available if we want a user to test a change.

* The `publish.yml` does NOT run automatically; it must be manually triggered from the Actions tab.  It does the build and package, creates a release and uploads it to the marketplace.  This will require a marketplace token; there are also some new changelog conventions which it requires us to observe.  These are described in `docs/maintenance/README.md` (for an example of them in action, see the Kubernetes extension, from which these were shamelessly copied).