### PR TITLE
Add changelog for 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Change Log
 
-## 0.0.2
+## [0.0.3]
+
+- Republish the extension under the new getporter publisher
+- Relicense from MIT to Apache 2 as part of moving to the CNCF
+- Added Installation browser
+- Update icon
+
+## [0.0.2]
 
 - Added telemetry - see the disclosure and opt-out statement in the README
 - Fixed duplicate output channels causing command tracing to be non-obvious
 
-## 0.0.1
+## [0.0.1]
 
 - Initial preview
 - Create project


### PR DESCRIPTION
Add a changelog entry for the new version 0.0.3. The github action will generate the release and tag.
