### PR TITLE
Fix version detection of package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "porter-vscode",
     "displayName": "Porter",
-    "description": "Package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command",
     "version": "0.0.3",
+    "description": "Package your application artifact, client tools, configuration and deployment logic together as a versioned bundle that you can distribute, and then install with a single command",
     "preview": true,
     "publisher": "getporter",
     "icon": "resources/porter.png",


### PR DESCRIPTION
https://github.com/martinbeentjes/npm-get-version-action has a bug where it uses grep and cat to find the package version. Since our description has the word "version" in it, it was picking up the entire description as the version number.

I am moving the description below our package version in the file to accommodate the bug until it can be fixed.
