### PR TITLE
Update extension to work with Porter v1

### DIFF
--- a/src/debugger/configuration-provider.ts
+++ b/src/debugger/configuration-provider.ts
@@ -66,6 +66,7 @@ async function resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefi
             return;
         }
 
+        // The namespace is set to "" to make the compiler happy. When porter install is run, the current namespace defined in the porter config file in PORTER_HOME is used.
         const installInputs: InstallInputs = { namespace: "", parameters: parameters.value, credentialSet: credentialSet.value };
 
         config.installInputs = installInputs;

--- a/src/debugger/configuration-provider.ts
+++ b/src/debugger/configuration-provider.ts
@@ -66,7 +66,7 @@ async function resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefi
             return;
         }
 
-        const installInputs: InstallInputs = { parameters: parameters.value, credentialSet: credentialSet.value };
+        const installInputs: InstallInputs = { namespace: "", parameters: parameters.value, credentialSet: credentialSet.value };
 
         config.installInputs = installInputs;
     }

--- a/src/debugger/runtime.ts
+++ b/src/debugger/runtime.ts
@@ -128,11 +128,11 @@ export class PorterInstallRuntime extends EventEmitter {
     private credentials: LazyVariableInfo[] | undefined = undefined;
 
     public async getCredentials(): Promise<LazyVariableInfo[]> {
-        if (this.credentials !== undefined)  {
+        if (this.credentials !== undefined) {
             return this.credentials;
         }
         if (this.actionInputs && this.actionInputs.credentialSet) {
-            const credentials = await porter.getCredentials(shell, this.actionInputs.credentialSet);
+            const credentials = await porter.getCredentials(shell, this.actionInputs.namespace, this.actionInputs.credentialSet);
             if (credentials.succeeded) {
                 this.credentials = credentials.result.credentials.map((c) => ({ name: c.name, value: () => this.evaluateCredential(c.source) }));
                 return this.credentials;
@@ -200,7 +200,7 @@ export class PorterInstallRuntime extends EventEmitter {
     }
 
     private run(stepEvent?: string) {
-        for (let ln = this.currentLine+1; ln < this.sourceLines.length; ln++) {
+        for (let ln = this.currentLine + 1; ln < this.sourceLines.length; ln++) {
             if (this.fireEventsForLine(ln, stepEvent)) {
                 this.currentLine = ln;
                 return true;
@@ -238,7 +238,7 @@ export class PorterInstallRuntime extends EventEmitter {
         return false;
     }
 
-    private sendEvent(event: string, ... args: any[]) {
+    private sendEvent(event: string, ...args: any[]) {
         setImmediate((_) => {
             this.emit(event, ...args);
         });

--- a/src/debugger/session-protocol.ts
+++ b/src/debugger/session-protocol.ts
@@ -8,6 +8,7 @@ export const EVENT_OUTPUT = 'output';
 export const EVENT_END = 'end';
 
 export interface InstallInputs {
+    readonly namespace: string;
     readonly parameters?: { [key: string]: string };
     readonly credentialSet?: string;
 }

--- a/src/explorer/installation/installation-explorer.ts
+++ b/src/explorer/installation/installation-explorer.ts
@@ -5,7 +5,7 @@ import { ViewLogs } from '../../commands/viewlogs';
 import { ViewOutputs } from '../../commands/viewoutputs';
 
 import * as porter from '../../porter/porter';
-import { Installation, InstallationHistoryEntry } from '../../porter/porter.objectmodel';
+import { Installation, Run } from '../../porter/porter.objectmodel';
 import { Shell } from '../../utils/shell';
 import { viewLogs } from '../../views/logs';
 import { viewOutputs } from '../../views/outputs';
@@ -48,68 +48,67 @@ export class InstallationExplorer implements vscode.TreeDataProvider<Installatio
 
 class InstallationNode implements Node<InstallationExplorerTreeNode>, ViewOutputs {
     readonly kind = 'installation' as const;
-    constructor(private readonly shell: Shell, private readonly installation: Installation) {}
+    constructor(private readonly shell: Shell, private readonly installation: Installation) { }
     async getChildren(): Promise<InstallationExplorerTreeNode[]> {
-        const installationDetail = await porter.getInstallationDetail(this.shell, this.installation.Name);
+        const installationDetail = await porter.getInstallationDetail(this.shell, this.installation.namespace, this.installation.name);
         if (!installationDetail.succeeded) {
             return [new ExplorerErrorNode(installationDetail.error[0])];
         }
-        return installationDetail.result.History.map((e) => new InstallationHistoryEntryNode(this.shell, e));
+        return installationDetail.result.history?.map((run) => new RunEntryNode(this.shell, run));
     }
     getTreeItem(): vscode.TreeItem {
-        const treeItem = new vscode.TreeItem(this.installation.Name, vscode.TreeItemCollapsibleState.Collapsed);
+        const fullName = this.installation.namespace ? `${this.installation.namespace}/${this.installation.name}` : this.installation.name;
+        const treeItem = new vscode.TreeItem(fullName, vscode.TreeItemCollapsibleState.Collapsed);
         treeItem.contextValue = 'porter.installation porter.has-outputs';
-        treeItem.tooltip = `Last action: ${this.installation.Action} (${this.installation.Status})\nat: ${displayTime(this.installation.Modified)}`;
+        treeItem.tooltip = `${this.installation._calculated.displayInstallationState} (${this.installation._calculated.displayInstallationStatus})\nat: ${displayTime(this.installation.status.modified)}`;
         return treeItem;
     }
 
     async viewOutputs(): Promise<CommandResult> {
-        const installationDetail = await porter.getInstallationDetail(this.shell, this.installation.Name);
-        if (!installationDetail.succeeded) {
-            await vscode.window.showErrorMessage(`Can't view outputs: ${installationDetail.error[0]}`);
+        const outputs = await porter.listInstallationOutputs(this.shell, this.installation.namespace, this.installation.name);
+        if (!outputs.succeeded) {
+            await vscode.window.showErrorMessage(`Can't view outputs: ${outputs.error[0]}`);
             return CommandResult.Failed;
         }
-        const title = `Porter Outputs - ${this.installation.Name}`;
-        await viewOutputs(title, installationDetail.result.Outputs);
+        const title = `Porter Outputs - ${this.installation.name}`;
+        await viewOutputs(title, outputs.result);
         return CommandResult.Succeeded;
     }
 }
 
-class InstallationHistoryEntryNode implements Node<InstallationExplorerTreeNode>, ViewLogs, CopyId {
-    readonly kind = 'installation-history-entry' as const;
-    constructor(private readonly shell: Shell, private readonly data: InstallationHistoryEntry) {}
+class RunEntryNode implements Node<InstallationExplorerTreeNode>, ViewLogs, CopyId {
+    readonly kind = 'run-entry' as const;
+    constructor(private readonly shell: Shell, private readonly data: Run) { }
     getChildren(): InstallationExplorerTreeNode[] | Promise<InstallationExplorerTreeNode[]> {
         return [];
     }
     getTreeItem(): vscode.TreeItem {
-        const treeItem = new vscode.TreeItem(`${this.data.Action} at ${displayTime(this.data.Timestamp)}`);
-        treeItem.contextValue = 'porter.installation-history-entry porter.has-copiable-id';
-        if (this.data.HasLogs) {
-            treeItem.contextValue += ' porter.has-logs';
-        }
+        const treeItem = new vscode.TreeItem(`${this.data.action} at ${displayTime(this.data.started)}`);
+        treeItem.contextValue = 'porter.run-entry porter.has-copiable-id';
+        treeItem.contextValue += ' porter.has-logs';
         return treeItem;
     }
 
     async viewLogs(): Promise<CommandResult> {
-        const logs = await porter.getClaimLogs(this.shell, this.data.ClaimID);
+        const logs = await porter.getRunLogs(this.shell, this.data.id);
         if (!logs.succeeded) {
             await vscode.window.showErrorMessage(`Can't view logs: ${logs.error[0]}`);
             return CommandResult.Failed;
         }
-        const title = `Porter Logs - ${this.data.ClaimID}`;
+        const title = `Porter Logs - ${this.data.id}`;
         await viewLogs(title, logs.result);
         return CommandResult.Succeeded;
     }
 
     async copyId(): Promise<CommandResult> {
-        vscode.env.clipboard.writeText(this.data.ClaimID);
+        vscode.env.clipboard.writeText(this.data.id);
         return CommandResult.Succeeded;
     }
 }
 
 export type InstallationExplorerTreeNode =
     InstallationNode |
-    InstallationHistoryEntryNode |
+    RunEntryNode |
     ExplorerErrorNode;
 
 function displayTime(timeString: string): string {

--- a/src/porter/porter.objectmodel.ts
+++ b/src/porter/porter.objectmodel.ts
@@ -1,9 +1,11 @@
 export interface CredentialInfo {
-    readonly Name: string;
-    readonly Modified: string;
+    readonly namespace: string;
+    readonly name: string;
+    readonly modified: string;
 }
 
 export interface CredentialSetContent {
+    readonly namespace: string;
     readonly name: string;
     readonly credentials: Credential[];
 }
@@ -48,34 +50,44 @@ export function isCommand(s: CredentialSource): s is ShellCommandCredentialSourc
 }
 
 export interface Installation {
-    readonly Name: string;
-    readonly Created: string;
-    readonly Modified: string;
-    readonly Action: string;
-    readonly Status: string;
-    readonly History: ReadonlyArray<InstallationHistoryEntry>;  // only has latest in practice
+    readonly namespace: string;
+    readonly name: string;
+    readonly status: InstallationStatus;
+    readonly _calculated: InstallationDisplayValues;
+}
+
+export interface InstallationStatus {
+    readonly resultStatus: string;
+    readonly created: string;
+    readonly modified: string;
+    readonly action: string;
+}
+
+export interface InstallationDisplayValues {
+    readonly displayInstallationState: string;
+    readonly displayInstallationStatus: string;
 }
 
 export interface InstallationDetail {
-    readonly Name: string;
-    readonly Created: string;
-    readonly Modified: string;
-    readonly Action: string;
-    readonly Status: string;
-    readonly Outputs: ReadonlyArray<InstallationOutput>;
-    readonly History: ReadonlyArray<InstallationHistoryEntry>;
+    readonly namespace: string;
+    readonly name: string;
+    readonly created: string;
+    readonly modified: string;
+    readonly action: string;
+    readonly status: string;
+    history: Run[];
 }
 
-export interface InstallationHistoryEntry {
-    readonly ClaimID: string;
-    readonly Action: string;
-    readonly Timestamp: string;
-    readonly Status: string;
-    readonly HasLogs: boolean;
+export interface Run {
+    readonly id: string;
+    readonly action: string;
+    readonly started: string;
+    readonly stopped: string;
+    readonly status: string;
 }
 
 export interface InstallationOutput {
-    readonly Name: string;
-    readonly Value: string;
-    readonly Type: string;
+    readonly name: string;
+    readonly value: string;
+    readonly type: string;
 }

--- a/src/views/outputs.ts
+++ b/src/views/outputs.ts
@@ -26,9 +26,9 @@ function renderMarkdown(title: string, outputs: ReadonlyArray<InstallationOutput
 }
 
 function renderOutput(output: InstallationOutput): string {
-    const valueLines = output.Value.split('\n');
+    const valueLines = output.value.split('\n');
     return [
-        `| ${output.Name} | ${output.Type} | ${valueLines[0]} |`,
+        `| ${output.name} | ${output.type} | ${valueLines[0]} |`,
         ...valueLines.slice(1).map((l) => `| | | ${l} |`)
     ].join('\n');
 }


### PR DESCRIPTION
When Porter released v1, it changed the json structure of some of its commands. For example, standardizing on a naming convention (camelCase), or splitting up some commands in two like seeing an installation and its history. I have updated the extension to work with the current v1 json structure of Porter's command output.

This doesn't impact the schema (autocomplete/intellisense) when viewing a porter.yaml, that is controlled by the `porter schema` command in Porter itself actually. What this does do is fix the Porter Installation panel that is displayed on the left side of the VS Code window. You can now list installations, see previous runs, their logs and outputs again.
